### PR TITLE
Update base image and dependencies to fix net/netip vulnerability

### DIFF
--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/operator-framework/ansible-operator:v1.34.2
+FROM quay.io/operator-framework/ansible-operator:v1.37.2
 
 COPY requirements.yml ${HOME}/requirements.yml
 RUN ansible-galaxy collection install -r ${HOME}/requirements.yml \


### PR DESCRIPTION
## Description
Updated Dockerfile and requirements file to use latest versions that patch the critical net/netip vulnerability.
## Issues
JIRA issue [[IBMIOT-828]](https://jsw.ibm.com/browse/IBMIOT-828)