### PR TITLE
[patch] ism_threadh_t is a number not a pointer (error on Fedora 42)

### DIFF
--- a/server_snmp/src/imaSnmpAgentInit.c
+++ b/server_snmp/src/imaSnmpAgentInit.c
@@ -36,7 +36,7 @@
 static int keep_running;	/* protected by mutex */
 static int snmp_agent_reinit; /* protected by mutex */
 
-static ism_threadh_t snmpAgentThread = NULL;
+static ism_threadh_t snmpAgentThread = 0;
 static pthread_mutex_t snmp_agent_lock;
 static pthread_mutex_t *snmp_agent_lock_p = NULL;
 


### PR DESCRIPTION
Small tidy up that prevents building on a modern gcc (like is used in rhel10)